### PR TITLE
tee: make DIR_HANDLE_MANAGER process-local

### DIFF
--- a/api/src/syscall/mod.rs
+++ b/api/src/syscall/mod.rs
@@ -617,9 +617,18 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             {
                 use tee_raw_sys::TEE_SUCCESS;
 
-                match handle_tee_syscall(sysno, uctx) {
+                use crate::tee_debug;
+                let result = handle_tee_syscall(sysno, uctx);
+                tee_debug!("<--- TEE syscall return sysno: {:?}", sysno);
+                match result {
                     Ok(_) => Ok(TEE_SUCCESS as isize),
-                    Err(errno) => Ok(errno as isize),
+                    Err(errno) => {
+                        error!(
+                            "TEE syscall failed: sysno: {:?}, error: {:#010X?}",
+                            sysno, errno
+                        );
+                        Ok(errno as isize)
+                    }
                 }
             }
             #[cfg(not(feature = "tee"))]

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -164,16 +164,6 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
 
     info!("{} exit with code: {}", curr.id_name(), exit_code);
 
-    // 在进程退出时清理 TEE 全局目录句柄缓存
-    // 原因：进程退出时内核会回收文件描述符，但 GLOBAL_DIR_HANDLE_MANAGER 是全局变量不会被清理
-    // 如果不清理，下次运行时缓存的 fd 可能被复用给其他文件，导致读取错误的数据
-    #[cfg(feature = "tee")]
-    {
-        if let Err(e) = crate::tee::tee_ree_fs::reset_global_dir_handle() {
-            warn!("Failed to reset TEE global dir handle: {:?}", e);
-        }
-    }
-
     let clear_child_tid = thr.clear_child_tid() as *mut u32;
     if clear_child_tid.vm_write(0).is_ok() {
         let key = FutexKey::new_current(clear_child_tid as usize);

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -164,6 +164,16 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
 
     info!("{} exit with code: {}", curr.id_name(), exit_code);
 
+    // 在进程退出时清理 TEE 全局目录句柄缓存
+    // 原因：进程退出时内核会回收文件描述符，但 GLOBAL_DIR_HANDLE_MANAGER 是全局变量不会被清理
+    // 如果不清理，下次运行时缓存的 fd 可能被复用给其他文件，导致读取错误的数据
+    #[cfg(feature = "tee")]
+    {
+        if let Err(e) = crate::tee::tee_ree_fs::reset_global_dir_handle() {
+            warn!("Failed to reset TEE global dir handle: {:?}", e);
+        }
+    }
+
     let clear_child_tid = thr.clear_child_tid() as *mut u32;
     if clear_child_tid.vm_write(0).is_ok() {
         let key = FutexKey::new_current(clear_child_tid as usize);

--- a/api/src/tee/fs_dirfile.rs
+++ b/api/src/tee/fs_dirfile.rs
@@ -410,6 +410,11 @@ pub fn tee_fs_dirfile_commit_writes(
     dirh: &mut TeeFsDirfileDirh,
     hash: Option<&mut [u8; TEE_FS_HTREE_HASH_SIZE]>,
 ) -> TeeResult {
+    tee_debug!(
+        "tee_fs_dirfile_commit_writes: dirh.fh.fd: {:?}, dirh.fh.ht.data.head.counter: {}",
+        dirh.fh.fd,
+        dirh.fh.ht.data.head.counter
+    );
     dirh.fops.commit_writes(&mut dirh.fh, hash)
 }
 

--- a/api/src/tee/fs_htree.rs
+++ b/api/src/tee/fs_htree.rs
@@ -246,6 +246,13 @@ impl HtreeNode {
 
 pub type Subtree = Option<Box<HtreeNode>>;
 
+// HtreeNode 使用 NonNull 作为 parent 指针，不是自动 Send 的
+// 但我们可以安全地实现 Send，因为：
+// 1. 整个 TeeFsHtree 被 Mutex 保护，所有访问都通过 Mutex 进行
+// 2. parent 指针的生命周期由 TeeFsHtree 保证，不会出现悬垂指针
+// 3. 树结构在同一线程中访问，不会出现并发修改
+unsafe impl Send for HtreeNode {}
+
 pub trait SubtreeExt {
     fn get_mut(&mut self) -> Option<&mut HtreeNode>;
 
@@ -420,11 +427,7 @@ pub fn rpc_write_head(
     vers: u8,
     head: &TeeFsHtreeImage,
 ) -> TeeResult {
-    tee_debug!(
-        "rpc_write_head: vers: {}, counter: {}",
-        vers,
-        head.counter
-    );
+    tee_debug!("rpc_write_head: vers: {}, counter: {}", vers, head.counter);
     let data_ptr: &[u8] = unsafe {
         core::slice::from_raw_parts(
             head as *const TeeFsHtreeImage as *const u8,
@@ -838,7 +841,9 @@ fn htree_sync_node_to_storage(
         meta = Some(&ht_data.imeta.meta);
         tee_debug!(
             "htree_sync_node_to_storage (root): counter: {}, root_node_vers: {}, flags: 0x{:04X}",
-            ht_data.head.counter, vers, node.node.flags
+            ht_data.head.counter,
+            vers,
+            node.node.flags
         );
     }
     let mut digest = [0u8; TEE_FS_HTREE_HASH_SIZE];
@@ -1431,17 +1436,36 @@ pub fn init_head_from_data(
         for idx in 0..2 {
             // Read version idx (0 or 1) of the head, consistent with C implementation
             rpc_read_head(storage, idx as u8, &mut heads[idx])?;
-            tee_debug!("init_head_from_data: read head[{}]: counter={}", idx, heads[idx].counter);
+            tee_debug!(
+                "init_head_from_data: read head[{}]: counter={}",
+                idx,
+                heads[idx].counter
+            );
         }
 
         let idx = get_idx_from_counter(heads[0].counter, heads[1].counter)
             .map_err(|_| TEE_ERROR_SECURITY)?;
-        tee_debug!("init_head_from_data: get_idx_from_counter result: idx={}, heads[0].counter={}, heads[1].counter={}", idx, heads[0].counter, heads[1].counter);
+        tee_debug!(
+            "init_head_from_data: get_idx_from_counter result: idx={}, heads[0].counter={}, \
+             heads[1].counter={}",
+            idx,
+            heads[0].counter,
+            heads[1].counter
+        );
 
         let node_ref = &mut ht.root.node;
-        tee_debug!("init_head_from_data: reading root node with vers: {}, heads[0].counter: {}, heads[1].counter: {}", idx, heads[0].counter, heads[1].counter);
+        tee_debug!(
+            "init_head_from_data: reading root node with vers: {}, heads[0].counter: {}, \
+             heads[1].counter: {}",
+            idx,
+            heads[0].counter,
+            heads[1].counter
+        );
         rpc_read_node(storage, 1, idx, node_ref)?;
-        tee_debug!("init_head_from_data: root node loaded, flags: 0x{:04X}", node_ref.flags);
+        tee_debug!(
+            "init_head_from_data: root node loaded, flags: 0x{:04X}",
+            node_ref.flags
+        );
 
         ht.data.head = heads[idx as usize];
     }
@@ -1562,8 +1586,12 @@ pub fn tee_fs_htree_sync_to_storage(
     let counter_after = ht.data.head.counter;
     let head_vers = (ht.data.head.counter & 1) as u8;
     tee_debug!(
-        "tee_fs_htree_sync_to_storage: counter_before: {}, counter_after: {}, head_vers: {}, root_flags: 0x{:04X}",
-        counter_before, counter_after, head_vers, ht.root.node.flags
+        "tee_fs_htree_sync_to_storage: counter_before: {}, counter_after: {}, head_vers: {}, \
+         root_flags: 0x{:04X}",
+        counter_before,
+        counter_after,
+        head_vers,
+        ht.root.node.flags
     );
 
     let storage = ht.storage.as_ref();
@@ -1751,8 +1779,13 @@ pub fn tee_fs_htree_read_block(
             0
         };
 
-        tee_debug!("tee_fs_htree_read_block: node.node.flags: 0x{:04X}, HTREE_NODE_COMMITTED_BLOCK: 0x{:04X}, block_vers: {}", 
-            node.node.flags, HTREE_NODE_COMMITTED_BLOCK as u16, vers);
+        tee_debug!(
+            "tee_fs_htree_read_block: node.node.flags: 0x{:04X}, HTREE_NODE_COMMITTED_BLOCK: \
+             0x{:04X}, block_vers: {}",
+            node.node.flags,
+            HTREE_NODE_COMMITTED_BLOCK as u16,
+            vers
+        );
 
         // extract iv and tag (these are Copy types, can be used directly)
         (vers, node.node.iv, node.node.tag)
@@ -1866,8 +1899,15 @@ pub fn tee_fs_htree_write_block(
             } else {
                 0
             };
-            tee_debug!("tee_fs_htree_write_block: block_num: {}, block_updated: {}, flags_before: 0x{:04X}, flags_after: 0x{:04X}, block_vers: {}", 
-                block_num, node.block_updated, flags_before, node.node.flags, vers);
+            tee_debug!(
+                "tee_fs_htree_write_block: block_num: {}, block_updated: {}, flags_before: \
+                 0x{:04X}, flags_after: 0x{:04X}, block_vers: {}",
+                block_num,
+                node.block_updated,
+                flags_before,
+                node.node.flags,
+                vers
+            );
             vers
         };
 

--- a/api/src/tee/fs_htree.rs
+++ b/api/src/tee/fs_htree.rs
@@ -420,6 +420,11 @@ pub fn rpc_write_head(
     vers: u8,
     head: &TeeFsHtreeImage,
 ) -> TeeResult {
+    tee_debug!(
+        "rpc_write_head: vers: {}, counter: {}",
+        vers,
+        head.counter
+    );
     let data_ptr: &[u8] = unsafe {
         core::slice::from_raw_parts(
             head as *const TeeFsHtreeImage as *const u8,
@@ -827,8 +832,14 @@ fn htree_sync_node_to_storage(
     } else {
         // Counter isn't updated yet, it's increased just before
         // writing the header.
+        // C version: vers = !(targ->ht->head.counter & 1);
+        // When counter is even, vers = 1; when counter is odd, vers = 0
         vers = ((ht_data.head.counter & 1) == 0) as u8;
         meta = Some(&ht_data.imeta.meta);
+        tee_debug!(
+            "htree_sync_node_to_storage (root): counter: {}, root_node_vers: {}, flags: 0x{:04X}",
+            ht_data.head.counter, vers, node.node.flags
+        );
     }
     let mut digest = [0u8; TEE_FS_HTREE_HASH_SIZE];
 
@@ -1420,13 +1431,17 @@ pub fn init_head_from_data(
         for idx in 0..2 {
             // Read version idx (0 or 1) of the head, consistent with C implementation
             rpc_read_head(storage, idx as u8, &mut heads[idx])?;
+            tee_debug!("init_head_from_data: read head[{}]: counter={}", idx, heads[idx].counter);
         }
 
         let idx = get_idx_from_counter(heads[0].counter, heads[1].counter)
             .map_err(|_| TEE_ERROR_SECURITY)?;
+        tee_debug!("init_head_from_data: get_idx_from_counter result: idx={}, heads[0].counter={}, heads[1].counter={}", idx, heads[0].counter, heads[1].counter);
 
         let node_ref = &mut ht.root.node;
+        tee_debug!("init_head_from_data: reading root node with vers: {}, heads[0].counter: {}, heads[1].counter: {}", idx, heads[0].counter, heads[1].counter);
         rpc_read_node(storage, 1, idx, node_ref)?;
+        tee_debug!("init_head_from_data: root node loaded, flags: 0x{:04X}", node_ref.flags);
 
         ht.data.head = heads[idx as usize];
     }
@@ -1542,10 +1557,17 @@ pub fn tee_fs_htree_sync_to_storage(
     htree_traverse_post_order_mut(ht, &mut htree_sync_node_to_storage)
         .inspect_err(|e| error!("htree_traverse_post_order_mut error! {:X?}", e))?;
 
+    let counter_before = ht.data.head.counter;
     update_root(ht)?;
+    let counter_after = ht.data.head.counter;
+    let head_vers = (ht.data.head.counter & 1) as u8;
+    tee_debug!(
+        "tee_fs_htree_sync_to_storage: counter_before: {}, counter_after: {}, head_vers: {}, root_flags: 0x{:04X}",
+        counter_before, counter_after, head_vers, ht.root.node.flags
+    );
 
     let storage = ht.storage.as_ref();
-    rpc_write_head(storage, (ht.data.head.counter & 1) as u8, &mut ht.data.head)?;
+    rpc_write_head(storage, head_vers, &mut ht.data.head)?;
 
     ht.data.dirty = false;
 
@@ -1729,6 +1751,9 @@ pub fn tee_fs_htree_read_block(
             0
         };
 
+        tee_debug!("tee_fs_htree_read_block: node.node.flags: 0x{:04X}, HTREE_NODE_COMMITTED_BLOCK: 0x{:04X}, block_vers: {}", 
+            node.node.flags, HTREE_NODE_COMMITTED_BLOCK as u16, vers);
+
         // extract iv and tag (these are Copy types, can be used directly)
         (vers, node.node.iv, node.node.tag)
     };
@@ -1831,15 +1856,19 @@ pub fn tee_fs_htree_write_block(
 
         // if block not updated, toggle committed flag
         let block_vers = {
+            let flags_before = node.node.flags;
             if !node.block_updated {
                 node.node.flags ^= HTREE_NODE_COMMITTED_BLOCK as u16;
             }
 
-            if (node.node.flags & HTREE_NODE_COMMITTED_BLOCK as u16) != 0 {
+            let vers = if (node.node.flags & HTREE_NODE_COMMITTED_BLOCK as u16) != 0 {
                 1
             } else {
                 0
-            }
+            };
+            tee_debug!("tee_fs_htree_write_block: block_num: {}, block_updated: {}, flags_before: 0x{:04X}, flags_after: 0x{:04X}, block_vers: {}", 
+                block_num, node.block_updated, flags_before, node.node.flags, vers);
+            vers
         };
 
         // allocate encryption buffer (使用之前获取的 block_size)

--- a/api/src/tee/tee_ree_fs.rs
+++ b/api/src/tee/tee_ree_fs.rs
@@ -12,15 +12,9 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use core::{
-    any::Any,
-    ffi::c_uint,
-    fmt::Debug,
-    ptr,
-    sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
-};
+use core::{any::Any, ffi::c_uint, fmt::Debug, ptr};
 
-use lazy_static::lazy_static;
+use scope_local::scope_local;
 use spin::{Mutex, RwLock};
 use tee_raw_sys::{TEE_STORAGE_PRIVATE, *};
 
@@ -309,7 +303,7 @@ pub fn ree_fs_rpc_write_init() -> TeeResult {
     Ok(())
 }
 
-pub trait TeeFsHtreeStorageOps: Debug + Any {
+pub trait TeeFsHtreeStorageOps: Debug + Any + Send + Sync {
     fn block_size(&self) -> usize;
 
     fn rpc_read_init(&self) -> TeeResult;
@@ -1196,133 +1190,110 @@ fn commit_dirh_writes(dirh: &mut TeeFsDirfileDirh) -> TeeResult {
     tee_fs_dirfile_commit_writes(dirh, None)
 }
 
-/// 完全对应C代码的语义
+/// Process level directory handle cache
+/// Using scope_local! to implement, the directory handle will be automatically cleaned up when the process exits, solving the fd invalid problem
+///
+/// Different from OP-TEE:
+/// - OP-TEE: ree_fs_dirh is a global variable in the TEE kernel, shared by multiple TAs
+/// - StarryOS: DIR_HANDLE_MANAGER is a process level variable, each process is independent
+///
+/// This design has the following advantages:
+/// 1. The fd and cache life cycle are consistent, and the cache will be automatically cleaned up when the process exits
+/// 2. No need to manually call reset
+/// 3. Code is more concise
+///
+/// TODO: multi-process support must be implemented
 pub struct ReeFsDirh {
-    /// 对应ree_fs_dirh_refcount
-    refcount: AtomicUsize,
-    /// 对应ree_fs_dirh
-    handle: AtomicPtr<TeeFsDirfileDirh>,
+    /// Directory handle cache
+    handle: Option<Box<TeeFsDirfileDirh>>,
+    /// Reference count (for compatibility with the put_dirh semantic of the C version)
+    refcount: usize,
+}
+
+impl Default for ReeFsDirh {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ReeFsDirh {
-    const fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            refcount: AtomicUsize::new(0),
-            handle: AtomicPtr::new(ptr::null_mut()),
+            handle: None,
+            refcount: 0,
         }
     }
 
-    /// 对应get_dirh
-    pub fn get_dirh(&self) -> TeeResult<*mut TeeFsDirfileDirh> {
-        let mut h = self.handle.load(Ordering::Acquire);
-        if h.is_null() {
-            let a = open_dirh()?;
-            h = Box::into_raw(a);
-            self.handle.store(h, Ordering::Release);
+    /// Get directory handle, if not exist, open it
+    pub fn get_dirh(&mut self) -> TeeResult<*mut TeeFsDirfileDirh> {
+        if self.handle.is_none() {
+            let dirh = open_dirh()?;
+            self.handle = Some(dirh);
         }
-        self.refcount.fetch_add(1, Ordering::AcqRel);
+        self.refcount += 1;
 
+        let h = self.handle.as_mut().unwrap().as_mut() as *mut TeeFsDirfileDirh;
         tee_debug!(
             "get_dirh: h with refcount: {:?} and h: {:?}",
-            self.refcount.load(Ordering::Acquire),
+            self.refcount,
             h
         );
         Ok(h)
     }
 
-    pub fn put_dirh_primitive(&self, close: bool) -> TeeResult {
-        loop {
-            let current = self.refcount.load(Ordering::Acquire);
-
-            if current == 0 {
-                warn!("put_dirh_primitive: refcount already 0 (double free or logic error)");
-                return Ok(());
-            }
-
-            // try to change refcount from current -> current - 1
-            if self
-                .refcount
-                .compare_exchange(current, current - 1, Ordering::AcqRel, Ordering::Acquire)
-                .is_err()
-            {
-                // 并发失败，重试
-                continue;
-            }
-
-            // Only these two cases need to be released:
-            // 1) Normal reference count reaches zero
-            // 2) close == true (force release)
-            if current == 1 || close {
-                let h = self.handle.swap(ptr::null_mut(), Ordering::AcqRel);
-                if !h.is_null() {
-                    unsafe {
-                        let mut boxed = Box::from_raw(h);
-                        close_dirh(&mut boxed)?;
-                        // drop(boxed) happens automatically
-                    }
-                }
-
-                // Ensure refcount is 0 (there may still be references in the close scenario)
-                self.refcount.store(0, Ordering::Release);
-            }
-
+    /// Release directory handle reference
+    pub fn put_dirh_primitive(&mut self, close: bool) -> TeeResult {
+        if self.refcount == 0 {
+            warn!("put_dirh_primitive: refcount already 0 (double free or logic error)");
             return Ok(());
         }
-    }
 
-    /// 对应open_dirh
-    pub fn set_handle(&self, handle: *mut TeeFsDirfileDirh) {
-        self.handle.store(handle, Ordering::Release);
-    }
+        self.refcount -= 1;
 
-    pub fn refcount(&self) -> usize {
-        self.refcount.load(Ordering::Acquire)
-    }
-
-    /// 重置 GLOBAL_DIR_HANDLE_MANAGER，清理缓存的 dirh
-    /// 在 TA 进程退出时调用，确保下次使用时从存储重新读取
-    pub fn reset(&self) -> TeeResult {
-        let h = self.handle.swap(ptr::null_mut(), Ordering::AcqRel);
-        if !h.is_null() {
-            unsafe {
-                let mut boxed = Box::from_raw(h);
-                close_dirh(&mut boxed)?;
+        // Only these two cases need to be released:
+        // 1) Normal reference count reaches zero
+        // 2) close == true (force release)
+        if self.refcount == 0 || close {
+            if let Some(mut dirh) = self.handle.take() {
+                close_dirh(&mut dirh)?;
             }
+            self.refcount = 0;
         }
-        self.refcount.store(0, Ordering::Release);
-        tee_debug!("ReeFsDirh::reset: cleared cached dirh");
+
         Ok(())
     }
 }
 
-// static GLOBAL_DIR_HANDLE_MANAGER: Once<ReeFsDirh> = Once::new();
-
-// pub fn get_global_manager() -> &'static ReeFsDirh {
-//     GLOBAL_DIR_HANDLE_MANAGER.call_once(|| ReeFsDirh::new())
-// }
-
-// GLOBAL_DIR_HANDLE_MANAGER 不需要锁进行保护，
-// ree_fs_ 系列函数会使用mutex保证线程安全
-lazy_static! {
-    pub static ref GLOBAL_DIR_HANDLE_MANAGER: ReeFsDirh = ReeFsDirh::new();
+impl Drop for ReeFsDirh {
+    fn drop(&mut self) {
+        // 进程退出时自动清理
+        if let Some(mut dirh) = self.handle.take() {
+            tee_debug!("ReeFsDirh::drop: cleaning up cached dirh");
+            let _ = close_dirh(&mut dirh);
+        }
+    }
 }
 
-// /// get_dirh
+// 进程级目录句柄管理器
+// 使用 scope_local! 实现进程级存储，进程退出时自动清理
+// 使用 Arc<Mutex<...>> 与 TEE_FD_TABLE 的设计保持一致
+scope_local! {
+    /// 进程级目录句柄缓存
+    /// 使用 Arc<Mutex<...>> 保证线程安全，与 TEE_FD_TABLE 设计一致
+    pub static DIR_HANDLE_MANAGER: Arc<Mutex<ReeFsDirh>> = Arc::new(Mutex::new(ReeFsDirh::new()));
+}
+
+/// 获取目录句柄
 pub fn get_dirh() -> TeeResult<*mut TeeFsDirfileDirh> {
-    GLOBAL_DIR_HANDLE_MANAGER.get_dirh()
+    DIR_HANDLE_MANAGER.lock().get_dirh()
 }
 
+/// 释放目录句柄引用
 pub fn put_dirh_primitive(close: bool) -> TeeResult {
-    GLOBAL_DIR_HANDLE_MANAGER.put_dirh_primitive(close)
+    DIR_HANDLE_MANAGER.lock().put_dirh_primitive(close)
 }
 
-/// 重置全局目录句柄缓存
-/// 在 TA 进程退出时调用，确保下次使用时从存储重新读取最新数据
-pub fn reset_global_dir_handle() -> TeeResult {
-    let _guard = REE_FS_MUTEX.lock();
-    GLOBAL_DIR_HANDLE_MANAGER.reset()
-}
-
+/// 释放目录句柄
 pub fn put_dirh(_dirh: &TeeFsDirfileDirh, close: bool) {
     let _ = put_dirh_primitive(close);
 }

--- a/api/src/tee/tee_svc_cryp.rs
+++ b/api/src/tee/tee_svc_cryp.rs
@@ -601,6 +601,7 @@ impl TeeCryptObjAttrOps for BigNum {
     }
 
     fn to_user(&self, buffer: &mut [u8], size_ref: &mut u64) -> TeeResult {
+        tee_debug!("BigNum::to_user: buffer.len(): {:#x?}, size_ref: {:x?}", buffer.len(), size_ref);
         let mut s: u64 = 0;
 
         // copy size from user
@@ -1948,6 +1949,7 @@ fn check_key_size(props: &tee_cryp_obj_type_props, key_size: size_t) -> TeeResul
 /// # Returns
 /// * `TeeResult` - the result of the operation
 pub fn syscall_cryp_obj_get_info(obj_id: c_ulong, info: *mut utee_object_info) -> TeeResult {
+    tee_debug!("syscall_cryp_obj_get_info: obj_id: {:#010X?}, info: {:#010X?}", obj_id, info);
     let info = unsafe { &mut *info };
 
     let mut o_info: utee_object_info = utee_object_info::default();
@@ -2033,6 +2035,13 @@ pub fn syscall_cryp_obj_get_attr(
     buffer: *mut c_void,
     size: *mut c_ulong,
 ) -> TeeResult {
+    tee_debug!(
+        "syscall_cryp_obj_get_attr: obj_id: {:x?}, attr_id: {:x?}, buffer: {:x?}, size: {:x?}",
+        obj_id,
+        attr_id,
+        buffer,
+        size
+    );
     let mut obj_usage = 0;
     let o_arc = tee_obj_get(obj_id as tee_obj_id_type)?;
     let mut o = o_arc.lock();

--- a/api/src/tee/tee_svc_cryp.rs
+++ b/api/src/tee/tee_svc_cryp.rs
@@ -601,7 +601,11 @@ impl TeeCryptObjAttrOps for BigNum {
     }
 
     fn to_user(&self, buffer: &mut [u8], size_ref: &mut u64) -> TeeResult {
-        tee_debug!("BigNum::to_user: buffer.len(): {:#x?}, size_ref: {:x?}", buffer.len(), size_ref);
+        tee_debug!(
+            "BigNum::to_user: buffer.len(): {:#x?}, size_ref: {:x?}",
+            buffer.len(),
+            size_ref
+        );
         let mut s: u64 = 0;
 
         // copy size from user
@@ -1949,7 +1953,11 @@ fn check_key_size(props: &tee_cryp_obj_type_props, key_size: size_t) -> TeeResul
 /// # Returns
 /// * `TeeResult` - the result of the operation
 pub fn syscall_cryp_obj_get_info(obj_id: c_ulong, info: *mut utee_object_info) -> TeeResult {
-    tee_debug!("syscall_cryp_obj_get_info: obj_id: {:#010X?}, info: {:#010X?}", obj_id, info);
+    tee_debug!(
+        "syscall_cryp_obj_get_info: obj_id: {:#010X?}, info: {:#010X?}",
+        obj_id,
+        info
+    );
     let info = unsafe { &mut *info };
 
     let mut o_info: utee_object_info = utee_object_info::default();
@@ -2059,9 +2067,10 @@ pub fn syscall_cryp_obj_get_attr(
         return Err(TEE_ERROR_BAD_PARAMETERS);
     }
 
-    info!(
+    tee_debug!(
         "attr_id: {:x?}, handleFlags: {:x?}",
-        attr_id, o.info.handleFlags
+        attr_id,
+        o.info.handleFlags
     );
     if attr_id & TEE_ATTR_FLAG_PUBLIC as c_ulong == 0 {
         if o.info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT != 0 {
@@ -2080,7 +2089,7 @@ pub fn syscall_cryp_obj_get_attr(
     let type_props = tee_svc_find_type_props(o.info.objectType).ok_or(TEE_ERROR_BAD_STATE)?;
 
     let idx = tee_svc_cryp_obj_find_type_attr_idx(attr_id as u32, type_props);
-    info!("idx: {}, have_attrs: {:x?}", idx, o.have_attrs);
+    tee_debug!("idx: {}, have_attrs: {:x?}", idx, o.have_attrs);
     if idx < 0 || (o.have_attrs & (1 << idx)) == 0 {
         return Err(TEE_ERROR_ITEM_NOT_FOUND);
     }

--- a/api/src/tee/tee_svc_storage.rs
+++ b/api/src/tee/tee_svc_storage.rs
@@ -321,6 +321,7 @@ pub fn syscall_storage_obj_open(
     let fops =
         tee_svc_storage_file_ops(storage_id as c_uint).map_err(|_| TEE_ERROR_ITEM_NOT_FOUND)?;
 
+    tee_debug!("syscall_storage_obj_open: flags: {:#010X?}, valid_flags: {:#010X?}", flags, valid_flags);
     if flags & !valid_flags != 0 {
         return Err(TEE_ERROR_BAD_PARAMETERS);
     }
@@ -421,7 +422,7 @@ fn tee_svc_storage_init_file(
         }
         tee_obj_attr_to_binary(o, &mut [], &mut attr_size)?;
         if attr_size > 0 {
-            attr = Vec::<u8>::with_capacity(attr_size).into_boxed_slice();
+            attr = vec![0u8; attr_size].into_boxed_slice();
             tee_obj_attr_to_binary(o, &mut attr, &mut attr_size)?;
         }
     } else {

--- a/api/src/tee/tee_svc_storage.rs
+++ b/api/src/tee/tee_svc_storage.rs
@@ -321,7 +321,11 @@ pub fn syscall_storage_obj_open(
     let fops =
         tee_svc_storage_file_ops(storage_id as c_uint).map_err(|_| TEE_ERROR_ITEM_NOT_FOUND)?;
 
-    tee_debug!("syscall_storage_obj_open: flags: {:#010X?}, valid_flags: {:#010X?}", flags, valid_flags);
+    tee_debug!(
+        "syscall_storage_obj_open: flags: {:#010X?}, valid_flags: {:#010X?}",
+        flags,
+        valid_flags
+    );
     if flags & !valid_flags != 0 {
         return Err(TEE_ERROR_BAD_PARAMETERS);
     }


### PR DESCRIPTION
Replace kernel-global DIR_HANDLE_MANAGER with a process-level cache using
scope_local!, so directory handles are cleaned up automatically on
process exit and stale fd reuse is avoided.